### PR TITLE
Make list of misspelled words from stdin

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,47 @@ packaged version of the dictionaries from
 https://build.opensuse.org/package/show/Documentation:Tools/suse-documentation-dicts-en.
 
 
+### Building a wordlist
+
+To update our custom dictionaries, it may be useful to output a list of words
+that hunspell would find.
+
+Before you can get a list, you need to apply the `cleanup.xsl` stylesheet on
+your XML file. This will eliminate all elements that are 
+
+1. Install some packages:
+
+     ```
+     sudo zypper install hunspell aspell
+     ```
+
+1. Rebuild the dictionaries:
+
+     ```
+     make
+     ```
+
+   After the command was successful, a new directory `build/` appears with the
+   file `en_US-suse-doc.dic`.
+
+
+1. Cleanup your DocBook file (replace `FILE` with the real file name):
+
+     ```
+     export DICPATH="$PWD/build/"
+     xsltproc --xinclude cleanup.xsl FILE | hunspell -H -i utf-8 -d en_US,en_US-suse-doc -l | sort | uniq
+     ```
+
+    The options mean:
+    
+    `-H`: The input file is in SGML/HTML format.
+    `-i`: Set input encoding
+    `-d`: Set dictionaries by their base names with or without paths.
+    `-l`: The "list" option is used to produce a list of misspelled words from the standard input.
+
+1. Investigate the output and add new words to the file list, if needed.
+
+
 ### Building the Dictionaries
 
 This repository allows for building an aspell RWS file, a Hunspell DIC file,

--- a/cleanup.xsl
+++ b/cleanup.xsl
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Purpose:
+    Filter a DocBook document to list unknown words find by hunspell
+
+  Output:
+    DocBook5 XML, but some nodes are supressed which are NOT relevant for spell checking:
+    * comments and processing instructions
+    * Block elements like screen, programlisting etc.
+    * Inline elements like filename, code, literal etc.
+
+  Example:
+    To get a list of unknown words, run:
+
+    xsltproc -xinclude cleanup.xsl FILE | hunspell -H -i utf-8 -d en_US,en_US-suse-doc -l
+
+  Author:     Thomas Schraitle, 2022
+
+-->
+<xsl:stylesheet version="1.0"
+  xmlns:d="http://docbook.org/ns/docbook"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+  <xsl:output method="xml"/>
+  <!--<xsl:strip-space elements="*"/>
+  <xsl:preserve-space elements="d:para"/>-->
+  
+  <xsl:template match="node() | @*" name="copy">
+    <xsl:copy>
+      <xsl:apply-templates select="@* | node()" />
+    </xsl:copy>
+  </xsl:template>
+
+  <xsl:template match="comment()"/>
+  <xsl:template match="processing-instruction()"/>
+
+  <!-- Block elements -->
+  <!-- The following elements are not needed -->
+  <xsl:template match="d:classsynopsis|d:destructorsynopsis|d:cmdsynopsis|d:constructorsynopsis|d:funsynopsis
+                       |d:fieldsynopsis
+                       |d:informalequation
+                       |d:methodsynopsis
+                       |d:production|d:programlisting|d:programlistingco
+                       |d:refsynopsisdiv
+                       |d:screen|d:screenco
+                       "/>
+
+  <!-- Inline Elements -->
+  <xsl:template match="d:abbrev|d:accel|d:acronym|d:address|d:affiliation|d:alt|d:anchor
+                       |d:arc|d:area|d:areaset|d:areaspec|d:arg|d:artpagenums|d:audiodata|d:authorinitials
+                       |d:classname|d:code|d:command|d:computeroutput
+                       |d:database
+                       |d:errorcode|d:errorname|d:errortext|d:errortype|d:exceptionname|d:extendedlink
+                       |d:fax|d:funcdef|d:funcparams|d:funcprototype|d:filename
+                       |d:initializer|d:inlineequation|d:interfacename|d:keycode|d:keycombo|d:keysym
+                       |d:literal
+                       |d:mathphrase
+                       |d:option
+                       |d:phone|d:pob|d:postcode
+                       |d:remark
+                       "/>
+
+</xsl:stylesheet>


### PR DESCRIPTION
This PR enhances the way how to create misspelled word list from existing XML files:

* Add `cleanup.xsl` to filter DocBook XML source.
  It removes any elements or comments which are not relevant  for spell-checking (like <screen> etc.)
* Update README with procedure